### PR TITLE
snapshot: upload BC snapshot of Feb 2023

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,9 @@
 
 ### Data
 
-[bc_data_202212.tgz
-](https://pub-10cd0733ed3540f1a5bd893cdcaf4027.r2.dev/bc_data_202212.tgz
-)
+[bc_data_202302.tgz](https://pub-10cd0733ed3540f1a5bd893cdcaf4027.r2.dev/bc-snapshot.tar)
 
-sha1sum checksum: 0ac461decc9dfdab04df8ddfa3b3b65ffc2de0cf
+md5sum checksum: d2aa8443768d724e33c46d1872467523
 
 
 
@@ -29,6 +27,6 @@ tar -xvf data.tgz
 
 Step 3: Replace Data
 - Stop the running bc node if you have one by `kill {pid}`, and make sure the node has shut down
-- Consider backup the original data: `mv ${BC_Home_Dir}/data mv ${BC_Home_Dir}/data`
+- Consider backup the original data: `mv ${BC_Home_Dir}/data mv ${BC_Home_Dir}/data_bak`
 - Replace the data: `mv <uncompressed data dir> ${BC_Home_Dir}/data`
 - Start the bc node again and check the logs


### PR DESCRIPTION
# Description 
This repo will be used to share the snapshots of BNB Beacon Chain.
This pr will share the snapshot of Feb, 2023.

# Rational
Upload BC data snapshot of Feb, 2023.

# Changes
* upload BC snapshot